### PR TITLE
WiP: Histogram performance: optimize floatBucketIterator, part 2

### DIFF
--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -2293,6 +2293,20 @@ func TestFloatBucketIteratorTargetSchema(t *testing.T) {
 	require.False(t, it.Next(), "negative iterator not exhausted")
 }
 
+func BenchmarkFloatHistogramAllBucketIterator(b *testing.B) {
+	rng := rand.New(rand.NewSource(0))
+
+	fh := createRandomFloatHistogram(rng, 50)
+
+	b.ReportAllocs() // the current implementation reports 1 alloc
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		for it := fh.AllReverseBucketIterator(); it.Next(); {
+		}
+	}
+}
+
 func BenchmarkFloatHistogramDetectReset(b *testing.B) {
 	rng := rand.New(rand.NewSource(0))
 


### PR DESCRIPTION
This is a follow up to https://github.com/prometheus/prometheus/pull/12937.

Before the change:
```
go test -bench=BenchmarkFloatHistogramAllBucketIterator -count=5
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/histogram
BenchmarkFloatHistogramAllBucketIterator-10    	   15499	     76847 ns/op	     336 B/op	       3 allocs/op
BenchmarkFloatHistogramAllBucketIterator-10    	   15615	     76683 ns/op	     336 B/op	       3 allocs/op
BenchmarkFloatHistogramAllBucketIterator-10    	   15619	     76910 ns/op	     336 B/op	       3 allocs/op
BenchmarkFloatHistogramAllBucketIterator-10    	   15626	     78845 ns/op	     336 B/op	       3 allocs/op
BenchmarkFloatHistogramAllBucketIterator-10    	   14961	     79613 ns/op	     336 B/op	       3 allocs/op
```

getBounds reduction (~4% improvement):
```
BenchmarkFloatHistogramAllBucketIterator-10    	   15912	     73546 ns/op	     336 B/op	       3 allocs/op
BenchmarkFloatHistogramAllBucketIterator-10    	   16345	     73166 ns/op	     336 B/op	       3 allocs/op
BenchmarkFloatHistogramAllBucketIterator-10    	   16388	     73134 ns/op	     336 B/op	       3 allocs/op
BenchmarkFloatHistogramAllBucketIterator-10    	   16255	     73131 ns/op	     336 B/op	       3 allocs/op
BenchmarkFloatHistogramAllBucketIterator-10    	   16378	     73587 ns/op	     336 B/op	       3 allocs/op
```

additionally, inlining iterators (~32% total improvement, allocs down from 3 to 1):
```
BenchmarkFloatHistogramAllBucketIterator-10    	   22753	     52239 ns/op	     320 B/op	       1 allocs/op
BenchmarkFloatHistogramAllBucketIterator-10    	   22912	     52255 ns/op	     320 B/op	       1 allocs/op
BenchmarkFloatHistogramAllBucketIterator-10    	   22954	     52169 ns/op	     320 B/op	       1 allocs/op
BenchmarkFloatHistogramAllBucketIterator-10    	   22932	     52238 ns/op	     320 B/op	       1 allocs/op
BenchmarkFloatHistogramAllBucketIterator-10    	   22940	     52474 ns/op	     320 B/op	       1 allocs/op
```
