### PR TITLE
[PERF] PromQL: memoize resulting metric hashes in VectorBinop

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1132,12 +1132,21 @@ type EvalSeriesHelper struct {
 	signature int
 }
 
+type metricHashes []uint64
+
+type metricWithHash struct {
+	metric labels.Labels
+	hash   uint64
+}
+
 // EvalNodeHelper stores extra information and caches for evaluating a single node across steps.
 type EvalNodeHelper struct {
 	// Evaluation timestamp.
 	Ts int64
 	// Vector that can be used for output.
 	Out Vector
+
+	hashes metricHashes
 
 	// Caches.
 	// funcHistogramQuantile and funcHistogramFraction for classic histograms.
@@ -1151,7 +1160,7 @@ type EvalNodeHelper struct {
 	// For binary vector matching.
 	rightSigs    map[int]Sample
 	matchedSigs  map[int]map[uint64]struct{}
-	resultMetric map[string]labels.Labels
+	resultMetric map[string]metricWithHash
 	numSigs      int
 
 	// For info series matching.
@@ -1240,7 +1249,7 @@ func (enh *EvalNodeHelper) resetHistograms(inVec Vector, arg parser.Expr) annota
 // function call results.
 // The prepSeries function (if provided) can be used to prepare the helper
 // for each series, then passed to each call funcCall.
-func (ev *evaluator) rangeEval(ctx context.Context, prepSeries func(labels.Labels) string, funcCall func([]Vector, Matrix, [][]EvalSeriesHelper, *EvalNodeHelper) (Vector, annotations.Annotations), exprs ...parser.Expr) (Matrix, annotations.Annotations) {
+func (ev *evaluator) rangeEval(ctx context.Context, prepSeries func(labels.Labels) string, funcCall func([]Vector, Matrix, [][]EvalSeriesHelper, *EvalNodeHelper) (Vector, metricHashes, annotations.Annotations), exprs ...parser.Expr) (Matrix, annotations.Annotations) {
 	numSteps := int((ev.endTimestamp-ev.startTimestamp)/ev.interval) + 1
 	matrixes := make([]Matrix, len(exprs))
 	origMatrixes := make([]Matrix, len(exprs))
@@ -1333,8 +1342,8 @@ func (ev *evaluator) rangeEval(ctx context.Context, prepSeries func(labels.Label
 
 		// Make the function call.
 		enh.Ts = ts
-		result, ws := funcCall(vectors, nil, bufHelpers, enh)
-		enh.Out = result[:0] // Reuse result vector.
+		result, hashes, ws := funcCall(vectors, nil, bufHelpers, enh)
+		enh.Out, enh.hashes = result[:0], hashes[:0] // Reuse result vector.
 		warnings.Merge(ws)
 
 		vecNumSamples := result.TotalSamples()
@@ -1367,8 +1376,13 @@ func (ev *evaluator) rangeEval(ctx context.Context, prepSeries func(labels.Label
 		}
 
 		// Add samples in output vector to output series.
-		for _, sample := range result {
-			h := sample.Metric.Hash()
+		for i, sample := range result {
+			var h uint64
+			if len(hashes) > 0 {
+				h = hashes[i]
+			} else {
+				h = sample.Metric.Hash()
+			}
 			ss, ok := seriess[h]
 			if ok {
 				if ss.ts == ts { // If we've seen this output series before at this timestamp, it's a duplicate.
@@ -1701,7 +1715,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 				sortedGrouping = append(sortedGrouping, valueLabel.Val)
 				slices.Sort(sortedGrouping)
 			}
-			return ev.rangeEval(ctx, nil, func(v []Vector, _ Matrix, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+			return ev.rangeEval(ctx, nil, func(v []Vector, _ Matrix, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, metricHashes, annotations.Annotations) {
 				return ev.aggregationCountValues(e, sortedGrouping, valueLabel.Val, v[0], enh)
 			}, e.Expr)
 		}
@@ -1778,9 +1792,9 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 
 		if !matrixArg {
 			// Does not have a matrix argument.
-			return ev.rangeEval(ctx, nil, func(v []Vector, _ Matrix, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+			return ev.rangeEval(ctx, nil, func(v []Vector, _ Matrix, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, metricHashes, annotations.Annotations) {
 				vec, annos := call(v, nil, e.Args, enh)
-				return vec, warnings.Merge(annos)
+				return vec, nil, warnings.Merge(annos)
 			}, e.Args...)
 		}
 
@@ -2007,9 +2021,9 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 	case *parser.BinaryExpr:
 		switch lt, rt := e.LHS.Type(), e.RHS.Type(); {
 		case lt == parser.ValueTypeScalar && rt == parser.ValueTypeScalar:
-			return ev.rangeEval(ctx, nil, func(v []Vector, _ Matrix, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+			return ev.rangeEval(ctx, nil, func(v []Vector, _ Matrix, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, metricHashes, annotations.Annotations) {
 				val := scalarBinop(e.Op, v[0][0].F, v[1][0].F)
-				return append(enh.Out, Sample{F: val}), nil
+				return append(enh.Out, Sample{F: val}), nil, nil
 			}, e.LHS, e.RHS)
 		case lt == parser.ValueTypeVector && rt == parser.ValueTypeVector:
 			// Function to compute the join signature for each series.
@@ -2017,41 +2031,41 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 			sigf := signatureFunc(e.VectorMatching.On, buf, e.VectorMatching.MatchingLabels...)
 			switch e.Op {
 			case parser.LAND:
-				return ev.rangeEval(ctx, sigf, func(v []Vector, _ Matrix, sh [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
-					return ev.VectorAnd(v[0], v[1], e.VectorMatching, sh[0], sh[1], enh), nil
+				return ev.rangeEval(ctx, sigf, func(v []Vector, _ Matrix, sh [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, metricHashes, annotations.Annotations) {
+					return ev.VectorAnd(v[0], v[1], e.VectorMatching, sh[0], sh[1], enh), nil, nil
 				}, e.LHS, e.RHS)
 			case parser.LOR:
-				return ev.rangeEval(ctx, sigf, func(v []Vector, _ Matrix, sh [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
-					return ev.VectorOr(v[0], v[1], e.VectorMatching, sh[0], sh[1], enh), nil
+				return ev.rangeEval(ctx, sigf, func(v []Vector, _ Matrix, sh [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, metricHashes, annotations.Annotations) {
+					return ev.VectorOr(v[0], v[1], e.VectorMatching, sh[0], sh[1], enh), nil, nil
 				}, e.LHS, e.RHS)
 			case parser.LUNLESS:
-				return ev.rangeEval(ctx, sigf, func(v []Vector, _ Matrix, sh [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
-					return ev.VectorUnless(v[0], v[1], e.VectorMatching, sh[0], sh[1], enh), nil
+				return ev.rangeEval(ctx, sigf, func(v []Vector, _ Matrix, sh [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, metricHashes, annotations.Annotations) {
+					return ev.VectorUnless(v[0], v[1], e.VectorMatching, sh[0], sh[1], enh), nil, nil
 				}, e.LHS, e.RHS)
 			default:
-				return ev.rangeEval(ctx, sigf, func(v []Vector, _ Matrix, sh [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
-					vec, err := ev.VectorBinop(e.Op, v[0], v[1], e.VectorMatching, e.ReturnBool, sh[0], sh[1], enh, e.PositionRange())
-					return vec, handleVectorBinopError(err, e)
+				return ev.rangeEval(ctx, sigf, func(v []Vector, _ Matrix, sh [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, metricHashes, annotations.Annotations) {
+					vec, hashes, err := ev.VectorBinop(e.Op, v[0], v[1], e.VectorMatching, e.ReturnBool, sh[0], sh[1], enh, e.PositionRange())
+					return vec, hashes, handleVectorBinopError(err, e)
 				}, e.LHS, e.RHS)
 			}
 
 		case lt == parser.ValueTypeVector && rt == parser.ValueTypeScalar:
-			return ev.rangeEval(ctx, nil, func(v []Vector, _ Matrix, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+			return ev.rangeEval(ctx, nil, func(v []Vector, _ Matrix, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, metricHashes, annotations.Annotations) {
 				vec, err := ev.VectorscalarBinop(e.Op, v[0], Scalar{V: v[1][0].F}, false, e.ReturnBool, enh, e.PositionRange())
-				return vec, handleVectorBinopError(err, e)
+				return vec, nil, handleVectorBinopError(err, e)
 			}, e.LHS, e.RHS)
 
 		case lt == parser.ValueTypeScalar && rt == parser.ValueTypeVector:
-			return ev.rangeEval(ctx, nil, func(v []Vector, _ Matrix, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+			return ev.rangeEval(ctx, nil, func(v []Vector, _ Matrix, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, metricHashes, annotations.Annotations) {
 				vec, err := ev.VectorscalarBinop(e.Op, v[1], Scalar{V: v[0][0].F}, true, e.ReturnBool, enh, e.PositionRange())
-				return vec, handleVectorBinopError(err, e)
+				return vec, nil, handleVectorBinopError(err, e)
 			}, e.LHS, e.RHS)
 		}
 
 	case *parser.NumberLiteral:
 		span.SetAttributes(attribute.Float64("value", e.Val))
-		return ev.rangeEval(ctx, nil, func(_ []Vector, _ Matrix, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
-			return append(enh.Out, Sample{F: e.Val, Metric: labels.EmptyLabels()}), nil
+		return ev.rangeEval(ctx, nil, func(_ []Vector, _ Matrix, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, metricHashes, annotations.Annotations) {
+			return append(enh.Out, Sample{F: e.Val, Metric: labels.EmptyLabels()}), nil, nil
 		})
 
 	case *parser.StringLiteral:
@@ -2216,7 +2230,7 @@ func (ev *evaluator) rangeEvalTimestampFunctionOverVectorSelector(ctx context.Co
 		seriesIterators[i] = storage.NewMemoizedIterator(it, durationMilliseconds(ev.lookbackDelta)-1)
 	}
 
-	return ev.rangeEval(ctx, nil, func(_ []Vector, _ Matrix, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+	return ev.rangeEval(ctx, nil, func(_ []Vector, _ Matrix, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, metricHashes, annotations.Annotations) {
 		if vs.Timestamp != nil {
 			// This is a special case for "timestamp()" when the @ modifier is used, to ensure that
 			// we return a point for each time step in this case.
@@ -2246,7 +2260,7 @@ func (ev *evaluator) rangeEvalTimestampFunctionOverVectorSelector(ctx context.Co
 		}
 		ev.samplesStats.UpdatePeak(ev.currentSamples)
 		vec, annos := call([]Vector{vec}, nil, e.Args, enh)
-		return vec, ws.Merge(annos)
+		return vec, nil, ws.Merge(annos)
 	})
 }
 
@@ -2639,12 +2653,12 @@ func (*evaluator) VectorUnless(lhs, rhs Vector, matching *parser.VectorMatching,
 }
 
 // VectorBinop evaluates a binary operation between two Vectors, excluding set operators.
-func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *parser.VectorMatching, returnBool bool, lhsh, rhsh []EvalSeriesHelper, enh *EvalNodeHelper, pos posrange.PositionRange) (Vector, error) {
+func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *parser.VectorMatching, returnBool bool, lhsh, rhsh []EvalSeriesHelper, enh *EvalNodeHelper, pos posrange.PositionRange) (Vector, metricHashes, error) {
 	if matching.Card == parser.CardManyToMany {
 		panic("many-to-many only allowed for set operators")
 	}
 	if len(lhs) == 0 || len(rhs) == 0 {
-		return nil, nil // Short-circuit: nothing is going to match.
+		return nil, nil, nil // Short-circuit: nothing is going to match.
 	}
 
 	// The control flow below handles one-to-one or many-to-one matching.
@@ -2725,10 +2739,10 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 		case !keep:
 			continue
 		}
-		metric := resultMetric(ls.Metric, rs.Metric, op, matching, enh)
-		if !ev.enableDelayedNameRemoval && returnBool {
-			metric = metric.DropReserved(schema.IsMetadataLabel)
-		}
+
+		dropMetricName := !ev.enableDelayedNameRemoval && returnBool
+		metric := resultMetric(ls.Metric, rs.Metric, op, matching, dropMetricName, enh)
+
 		insertedSigs, exists := matchedSigs[sig]
 		if matching.Card == parser.CardOneToOne {
 			if exists {
@@ -2739,7 +2753,7 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 			// In many-to-one matching the grouping labels have to ensure a unique metric
 			// for the result Vector. Check whether those labels have already been added for
 			// the same matching labels.
-			insertSig := metric.Hash()
+			insertSig := metric.hash
 
 			if !exists {
 				insertedSigs = map[uint64]struct{}{}
@@ -2751,13 +2765,14 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 		}
 
 		enh.Out = append(enh.Out, Sample{
-			Metric:   metric,
+			Metric:   metric.metric,
 			F:        floatValue,
 			H:        histogramValue,
 			DropName: returnBool,
 		})
+		enh.hashes = append(enh.hashes, metric.hash)
 	}
-	return enh.Out, lastErr
+	return enh.Out, enh.hashes, lastErr
 }
 
 func signatureFunc(on bool, b []byte, names ...string) func(labels.Labels) string {
@@ -2776,9 +2791,9 @@ func signatureFunc(on bool, b []byte, names ...string) func(labels.Labels) strin
 
 // resultMetric returns the metric for the given sample(s) based on the Vector
 // binary operation and the matching options.
-func resultMetric(lhs, rhs labels.Labels, op parser.ItemType, matching *parser.VectorMatching, enh *EvalNodeHelper) labels.Labels {
+func resultMetric(lhs, rhs labels.Labels, op parser.ItemType, matching *parser.VectorMatching, dropMetricName bool, enh *EvalNodeHelper) metricWithHash {
 	if enh.resultMetric == nil {
-		enh.resultMetric = make(map[string]labels.Labels, len(enh.Out))
+		enh.resultMetric = make(map[string]metricWithHash, len(enh.Out))
 	}
 
 	enh.resetBuilder(lhs)
@@ -2794,7 +2809,7 @@ func resultMetric(lhs, rhs labels.Labels, op parser.ItemType, matching *parser.V
 	}
 	str := string(enh.lblResultBuf)
 
-	if changesMetricSchema(op) {
+	if dropMetricName || changesMetricSchema(op) {
 		// Setting empty Metadata causes the deletion of those if they exists.
 		schema.Metadata{}.SetToLabels(enh.lb)
 	}
@@ -2815,8 +2830,13 @@ func resultMetric(lhs, rhs labels.Labels, op parser.ItemType, matching *parser.V
 		}
 	}
 
-	ret := enh.lb.Labels()
+	metric := enh.lb.Labels()
+	ret := metricWithHash{
+		metric: metric,
+		hash:   metric.Hash(),
+	}
 	enh.resultMetric[str] = ret
+
 	return ret
 }
 
@@ -3523,7 +3543,7 @@ seriesLoop:
 
 // aggregationCountValues evaluates count_values on vec.
 // Outputs as many series per group as there are values in the input.
-func (*evaluator) aggregationCountValues(e *parser.AggregateExpr, grouping []string, valueLabel string, vec Vector, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+func (*evaluator) aggregationCountValues(e *parser.AggregateExpr, grouping []string, valueLabel string, vec Vector, enh *EvalNodeHelper) (Vector, metricHashes, annotations.Annotations) {
 	type groupCount struct {
 		labels labels.Labels
 		count  int
@@ -3566,7 +3586,7 @@ func (*evaluator) aggregationCountValues(e *parser.AggregateExpr, grouping []str
 			F:      float64(aggr.count),
 		})
 	}
-	return enh.Out, nil
+	return enh.Out, nil, nil
 }
 
 func (ev *evaluator) cleanupMetricLabels(v parser.Value) {


### PR DESCRIPTION
This is the second PR in a series of PromQL join optimizations that I am planning. It is stacked on top of https://github.com/prometheus/prometheus/pull/17131.

The original implementation is recomputing result metric hashes on every step. With this change, we are caching the hash values alongside the result metrics. Also, we return those hashes from `VectorBinop`, so that they can be reused by `rangeEval` when constructing result matrix (this PR focuses just on improving `VectorBinop` performance, but the change paves way for similar improvements in other code pats as well).

Benchmark results (relative to https://github.com/prometheus/prometheus/pull/17131):
```
                                                                                                                │ after1.txt  │             after2.txt              │
                                                                                                                │   sec/op    │   sec/op     vs base                │
JoinQuery/expr=rpc_request_success_total_+_rpc_request_error_total,steps=10000-10                                  3.984 ± 2%    3.641 ± 7%   -8.61% (p=0.000 n=10)
JoinQuery/expr=rpc_request_success_total_+_ON_(job,_instance)_GROUP_LEFT_rpc_request_error_total,steps=10000-10    4.769 ± 2%    4.127 ± 4%  -13.46% (p=0.000 n=10)
JoinQuery/expr=rpc_request_success_total_AND_rpc_request_error_total{instance=~"0.*"},steps=10000-10              619.3m ± 2%   598.3m ± 1%   -3.39% (p=0.000 n=10)
JoinQuery/expr=rpc_request_success_total_OR_rpc_request_error_total{instance=~"0.*"},steps=10000-10                1.475 ± 1%    1.502 ± 8%   +1.84% (p=0.009 n=10)
JoinQuery/expr=rpc_request_success_total_UNLESS_rpc_request_error_total{instance=~"0.*"},steps=10000-10            1.434 ± 1%    1.453 ± 1%   +1.31% (p=0.000 n=10)
geomean                                                                                                            1.902         1.814        -4.65%

                                                                                                                │  after1.txt  │             after2.txt              │
                                                                                                                │     B/op     │     B/op      vs base               │
JoinQuery/expr=rpc_request_success_total_+_rpc_request_error_total,steps=10000-10                                 54.44Mi ± 1%   54.49Mi ± 1%       ~ (p=0.052 n=10)
JoinQuery/expr=rpc_request_success_total_+_ON_(job,_instance)_GROUP_LEFT_rpc_request_error_total,steps=10000-10   1.245Gi ± 0%   1.245Gi ± 0%  +0.04% (p=0.000 n=10)
JoinQuery/expr=rpc_request_success_total_AND_rpc_request_error_total{instance=~"0.*"},steps=10000-10              38.32Mi ± 1%   38.27Mi ± 1%  -0.14% (p=0.029 n=10)
JoinQuery/expr=rpc_request_success_total_OR_rpc_request_error_total{instance=~"0.*"},steps=10000-10               38.69Mi ± 1%   38.65Mi ± 1%       ~ (p=0.063 n=10)
JoinQuery/expr=rpc_request_success_total_UNLESS_rpc_request_error_total{instance=~"0.*"},steps=10000-10           38.18Mi ± 1%   38.36Mi ± 1%       ~ (p=0.280 n=10)
geomean                                                                                                           82.95Mi        83.01Mi       +0.07%

                                                                                                                │ after1.txt  │             after2.txt             │
                                                                                                                │  allocs/op  │  allocs/op   vs base               │
JoinQuery/expr=rpc_request_success_total_+_rpc_request_error_total,steps=10000-10                                 562.8k ± 0%   562.8k ± 0%       ~ (p=0.183 n=10)
JoinQuery/expr=rpc_request_success_total_+_ON_(job,_instance)_GROUP_LEFT_rpc_request_error_total,steps=10000-10   20.57M ± 0%   20.57M ± 0%       ~ (p=0.446 n=10)
JoinQuery/expr=rpc_request_success_total_AND_rpc_request_error_total{instance=~"0.*"},steps=10000-10              309.2k ± 0%   308.6k ± 0%  -0.18% (p=0.000 n=10)
JoinQuery/expr=rpc_request_success_total_OR_rpc_request_error_total{instance=~"0.*"},steps=10000-10               309.2k ± 0%   308.6k ± 0%  -0.18% (p=0.001 n=10)
JoinQuery/expr=rpc_request_success_total_UNLESS_rpc_request_error_total{instance=~"0.*"},steps=10000-10           309.2k ± 0%   308.6k ± 0%  -0.19% (p=0.000 n=10)
geomean                                                                                                           807.0k        806.1k       -0.11%
```

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```
